### PR TITLE
Update logic for inviting new contributors

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -3,7 +3,7 @@
     "onlyForOrgMembers": false
   },
   "rules": {
-    "pull_request.closed": [
+    "pull_request.closed(pull_request.state == "merged")": [
       "gatsbyjs/peril-gatsbyjs@org/invite-collaborator.ts"
     ],
     "issues.opened": ["gatsbyjs/peril-gatsbyjs@org/emptybody.ts"]

--- a/tests/emptybody.test.ts
+++ b/tests/emptybody.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
   dm.danger = {
     github: {
       repository: {
-        owner: "Moya"
+        owner: "gatsbyjs"
       },
       issue: {
         user: {

--- a/tests/invite-collaborator.test.ts
+++ b/tests/invite-collaborator.test.ts
@@ -19,9 +19,9 @@ beforeEach(() => {
         }
       },
       api: {
-        repos: {
-          checkCollaborator: () =>
-            Promise.resolve({ meta: { status: '404 Not Found' } })
+        orgs: {
+          getTeamMembership: () =>
+            Promise.resolve({ meta: { status: '404' } })
         },
         issues: {
           createComment: jest.fn()
@@ -41,15 +41,8 @@ describe('a closed pull request', () => {
 
   it('was merged and authored by an existing collaborator', () => {
     dm.danger.github.pr.merged = true;
-    dm.danger.github.api.repos.checkCollaborator = () =>
+    dm.danger.github.api.orgs.getTeamMembership = () =>
       Promise.resolve({ meta: { status: '204 No Content' } });
-    return inviteCollaborator().then(() => {
-      expect(dm.danger.github.api.issues.createComment).not.toBeCalled();
-    });
-  });
-
-  it('was not merged', () => {
-    dm.danger.github.pr.merged = false;
     return inviteCollaborator().then(() => {
       expect(dm.danger.github.api.issues.createComment).not.toBeCalled();
     });


### PR DESCRIPTION
## Summary
- Only sends out the invite once by checking if this is the users first PR (some people reject and don't want to be spammed)
- Uses a keypath in the settings JSON to check for a merged pr

## Notes
I'm not a JavaScript developer and this is my first time writing JS in 2 months 😇 Please review