### PR TITLE
Drop the organization prefix on rules JSON

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -12,7 +12,7 @@
   },
   "repos": {
     "gatsbyjs/peril-gatsbyjs": {
-      "issues.opened": "gatsbyjs/peril-gatsbyjs@org/labeler.ts"
+      "issues.opened": "org/labeler.ts"
     }
   }
 }


### PR DESCRIPTION
### Summary
I'm thinking that maybe peril cannot find the file with the current syntax. It would make sense that it gets the organization info from the key and thus it doesn't need to be included in the file path.

### Note
@jlengstorf If you merge this, you will need to restart the peril server for it to take effect