### PR TITLE
Exclude archived repos from search

### DIFF
--- a/tasks/stale.ts
+++ b/tasks/stale.ts
@@ -40,7 +40,7 @@ const getRepoFromUrl = (url: string) => url.split("/").pop();
 const search = async (days: number, query: string) => {
   const api = danger.github.api;
   const timestamp = dateDaysAgo(endOfToday(), days);
-  const q = `-label:"${EXEMPT_LABEL}" org:${owner} type:issue state:open updated:<${timestamp} ${query}`;
+  const q = `-label:"${EXEMPT_LABEL}" org:${owner} type:issue state:open archived:false updated:<${timestamp} ${query}`;
   const searchResponse = await api.search.issues({
     q,
     order: "asc",


### PR DESCRIPTION
Archived repos are read-only, so there's no way to edit or label existing issues.

Should fix:

```
Stale task: found 5 issues to label 
Dec 08 09:06:01 gatsby-peril app/web.1: Could not run issues.addLabels with options {"owner":"gatsbyjs","repo":"gatsby-starter-documentation","number":10,"labels":["stale?"]} 
Dec 08 09:06:01 gatsby-peril app/web.1:  Error was {"message":"Repository was archived so is read-only.","documentation_url":"https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue"} 
Dec 08 09:06:01 gatsby-peril app/web.1: Set env var DEBUG=octokit:rest* for extended logging info. 
```