### PR TITLE
Add more error logging in the labeler

### DIFF
--- a/rules/labeler.ts
+++ b/rules/labeler.ts
@@ -1,5 +1,19 @@
 import { danger } from 'danger';
 
+interface ApiError {
+  action: string;
+  opts: object;
+  error: any;
+}
+
+export const logApiError = ({ action, opts, error }: ApiError) => {
+  const msg = `Could not run ${action} with options ${JSON.stringify(
+    opts
+  )}\n Error was ${error}\nSet env var DEBUG=octokit:rest* for extended logging info.`;
+  console.warn(msg);
+};
+
+
 const questionWords: Set<string> = new Set([
   'how',
   'who',
@@ -62,12 +76,19 @@ export const labeler = async () => {
   }
 
   if (labels.size > 0) {
-    await danger.github.api.issues.addLabels({
+    const opts = {
       owner: repo.owner.login,
       repo: repo.name,
       number: issue.number,
       labels: Array.from(labels)
-    });
+    }
+
+    try {
+      await danger.github.api.issues.addLabels(opts);
+    } catch (error) {
+      logApiError({ action: `issues.addLabel`, opts, error });
+    }
+
   }
 };
 

--- a/tasks/stale.ts
+++ b/tasks/stale.ts
@@ -2,6 +2,7 @@ import { danger, peril } from "danger";
 import * as endOfToday from "date-fns/end_of_today";
 import * as subDays from "date-fns/sub_days";
 import * as format from "date-fns/format";
+import { IssueComment } from "github-webhook-event-types";
 
 const owner = `gatsbyjs`;
 
@@ -29,7 +30,7 @@ const logApiError = ({ action, opts, error }: ApiError) => {
   const msg = `Could not run ${action} with options ${JSON.stringify(
     opts
   )}\n Error was ${error}\nSet env var DEBUG=octokit:rest* for extended logging info.`;
-  console.log(msg);
+  console.warn(msg);
 };
 
 // url format is "https://api.github.com/repos/<orgname>/<reponame>"


### PR DESCRIPTION
Peril is crashing when new issues are opened, this is basically a blind attempt at narrowing down the cause. It seems like it's useful to add whether it catches the source of the bug or not.

Peril doesn't do relative imports when running on Heroku, so this logging code is just copy-pasted from the stalebot file which is not ideal. 

Here's the current (before this PR) logging when an issue is opened: 

```
Dec 10 15:10:43 gatsby-peril app/web.1: info: ## issues.opened on unknown on gatsbyjs/gatsby 
Dec 10 15:10:43 gatsby-peril app/web.1: info:    2 runs needed: gatsbyjs/peril-gatsbyjs@rules/emptybody.ts and gatsbyjs/peril-gatsbyjs@rules/labeler.ts 
Dec 10 15:10:43 gatsby-peril app/web.1: info: [runner] - Commenting, with results:  
Dec 10 15:10:43 gatsby-peril app/web.1: mds: 0 
Dec 10 15:10:43 gatsby-peril app/web.1: messages: 0 
Dec 10 15:10:43 gatsby-peril app/web.1: warns: 0 
Dec 10 15:10:43 gatsby-peril app/web.1: fails: 0 
Dec 10 15:10:43 gatsby-peril app/web.1: No issues or messages were sent. Removing any existing messages. 
Dec 10 15:10:43 gatsby-peril app/web.1: error: UnhandledRejection Error:  TypeError: Cannot read property 'id' of undefined 
Dec 10 15:10:43 gatsby-peril app/web.1:     at Executor.<anonymous> (/app/node_modules/danger/distribution/runner/Executor.js:397:92) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at step (/app/node_modules/danger/distribution/runner/Executor.js:32:23) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at Object.next (/app/node_modules/danger/distribution/runner/Executor.js:13:53) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at /app/node_modules/danger/distribution/runner/Executor.js:7:71 
Dec 10 15:10:43 gatsby-peril app/web.1:     at new Promise (<anonymous>) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at __awaiter (/app/node_modules/danger/distribution/runner/Executor.js:3:12) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at Executor.deleteInlineComment (/app/node_modules/danger/distribution/runner/Executor.js:394:16) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at Executor.<anonymous> (/app/node_modules/danger/distribution/runner/Executor.js:247:51) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at step (/app/node_modules/danger/distribution/runner/Executor.js:32:23) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at Object.next (/app/node_modules/danger/distribution/runner/Executor.js:13:53) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at fulfilled (/app/node_modules/danger/distribution/runner/Executor.js:4:58) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at process._tickCallback (internal/process/next_tick.js:68:7) 
Dec 10 15:10:43 gatsby-peril app/web.1: /app/out/peril.js:25 
Dec 10 15:10:43 gatsby-peril app/web.1:         throw reason; 
Dec 10 15:10:43 gatsby-peril app/web.1:         ^ 
Dec 10 15:10:43 gatsby-peril app/web.1: TypeError: Cannot read property 'id' of undefined 
Dec 10 15:10:43 gatsby-peril app/web.1:     at Executor.<anonymous> (/app/node_modules/danger/distribution/runner/Executor.js:397:92) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at step (/app/node_modules/danger/distribution/runner/Executor.js:32:23) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at Object.next (/app/node_modules/danger/distribution/runner/Executor.js:13:53) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at /app/node_modules/danger/distribution/runner/Executor.js:7:71 
Dec 10 15:10:43 gatsby-peril app/web.1:     at new Promise (<anonymous>) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at __awaiter (/app/node_modules/danger/distribution/runner/Executor.js:3:12) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at Executor.deleteInlineComment (/app/node_modules/danger/distribution/runner/Executor.js:394:16) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at Executor.<anonymous> (/app/node_modules/danger/distribution/runner/Executor.js:247:51) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at step (/app/node_modules/danger/distribution/runner/Executor.js:32:23) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at Object.next (/app/node_modules/danger/distribution/runner/Executor.js:13:53) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at fulfilled (/app/node_modules/danger/distribution/runner/Executor.js:4:58) 
Dec 10 15:10:43 gatsby-peril app/web.1:     at process._tickCallback (internal/process/next_tick.js:68:7) 
```